### PR TITLE
feat: pass-through flags for manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ EXAMPLES
     $ sf jsc apex schedule export -j "Auto" -d tmp/dev
 ```
 
-_See code: [src/commands/jsc/apex/schedule/export.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/apex/schedule/export.ts)_
+_See code: [src/commands/jsc/apex/schedule/export.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/apex/schedule/export.ts)_
 
 ## `sf jsc apex schedule manage`
 
@@ -155,7 +155,7 @@ FLAG DESCRIPTIONS
     the command may still fail, when run without this flag.
 ```
 
-_See code: [src/commands/jsc/apex/schedule/manage.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/apex/schedule/manage.ts)_
+_See code: [src/commands/jsc/apex/schedule/manage.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/apex/schedule/manage.ts)_
 
 ## `sf jsc apex schedule start`
 
@@ -219,7 +219,7 @@ FLAG DESCRIPTIONS
     messages. If this doesn't help, use the --trace flag to output full debug logs from the execution.
 ```
 
-_See code: [src/commands/jsc/apex/schedule/start.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/apex/schedule/start.ts)_
+_See code: [src/commands/jsc/apex/schedule/start.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/apex/schedule/start.ts)_
 
 ## `sf jsc apex schedule stop`
 
@@ -284,7 +284,7 @@ FLAG DESCRIPTIONS
     messages. If this doesn't help, use the --trace flag to output full debug logs from the execution.
 ```
 
-_See code: [src/commands/jsc/apex/schedule/stop.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/apex/schedule/stop.ts)_
+_See code: [src/commands/jsc/apex/schedule/stop.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/apex/schedule/stop.ts)_
 
 ## `sf jsc data export`
 
@@ -318,7 +318,7 @@ EXAMPLES
   $ sf jsc data export
 ```
 
-_See code: [src/commands/jsc/data/export.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/data/export.ts)_
+_See code: [src/commands/jsc/data/export.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/data/export.ts)_
 
 ## `sf jsc maintain garbage collect`
 
@@ -393,7 +393,7 @@ FLAG DESCRIPTIONS
     needed, if you specify at least one package flag.
 ```
 
-_See code: [src/commands/jsc/maintain/garbage/collect.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/maintain/garbage/collect.ts)_
+_See code: [src/commands/jsc/maintain/garbage/collect.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/maintain/garbage/collect.ts)_
 
 ## `sf jsc manifest rollout`
 
@@ -427,7 +427,7 @@ EXAMPLES
   $ sf jsc manifest rollout
 ```
 
-_See code: [src/commands/jsc/manifest/rollout.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/manifest/rollout.ts)_
+_See code: [src/commands/jsc/manifest/rollout.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/manifest/rollout.ts)_
 
 ## `sf jsc manifest validate`
 
@@ -459,6 +459,6 @@ EXAMPLES
   $ sf jsc manifest validate
 ```
 
-_See code: [src/commands/jsc/manifest/validate.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.13.2/src/commands/jsc/manifest/validate.ts)_
+_See code: [src/commands/jsc/manifest/validate.ts](https://github.com/j-schreiber/js-sf-cli-plugin/blob/v0.14.0/src/commands/jsc/manifest/validate.ts)_
 
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@j-schreiber/sf-plugin",
   "description": "Salesforce plugin to orchestrate multi-org deployments, ease org maintenance and migrate data.",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/j-schreiber/js-sf-cli-plugin"

--- a/src/common/utils/sfCommandConfig.ts
+++ b/src/common/utils/sfCommandConfig.ts
@@ -1,0 +1,4 @@
+export type SfCommandConfig = {
+  args: string[];
+  name?: string;
+};

--- a/src/common/utils/wrapChildprocess.ts
+++ b/src/common/utils/wrapChildprocess.ts
@@ -1,6 +1,6 @@
 import util from 'node:util';
 import childProcess from 'node:child_process';
-import { SfCommandConfig } from '../../release-manifest/artifact-deploy-strategies/artifactDeployStrategy.js';
+import { SfCommandConfig } from './sfCommandConfig.js';
 
 const exec = util.promisify(childProcess.exec);
 

--- a/src/release-manifest/artifact-deploy-strategies/artifactDeployStrategy.ts
+++ b/src/release-manifest/artifact-deploy-strategies/artifactDeployStrategy.ts
@@ -28,8 +28,3 @@ export type ArtifactDeployStrategy = {
    */
   resolve(targetOrg: Connection, devhubOrg: Connection): Promise<ZArtifactDeployResultType>;
 };
-
-export type SfCommandConfig = {
-  args: string[];
-  name?: string;
-};

--- a/src/release-manifest/artifact-deploy-strategies/unlockedPackageInstallStep.ts
+++ b/src/release-manifest/artifact-deploy-strategies/unlockedPackageInstallStep.ts
@@ -48,6 +48,7 @@ export default class UnlockedPackageInstallStep implements ArtifactDeployStrateg
     if (this.internalState.useInstallationKey) {
       packageInstallCmd.addFlag('installation-key', this.internalState.installationKey);
     }
+    packageInstallCmd.parseFlags(this.artifact.flags);
     const result = await OclifUtils.execCoreCommand(packageInstallCmd.buildConfig());
     this.internalState.status = result.status === 0 ? DeployStatus.Enum.Success : DeployStatus.Enum.Failed;
     if (result.status !== 0) {

--- a/src/release-manifest/artifact-deploy-strategies/unpackagedDeployStep.ts
+++ b/src/release-manifest/artifact-deploy-strategies/unpackagedDeployStep.ts
@@ -37,6 +37,7 @@ export default class UnpackagedDeployStep implements ArtifactDeployStrategy {
       { name: 'source-dir', value: this.internalState.sourcePath! },
       { name: 'wait', value: '10' },
     ]);
+    projectDeployCmd.parseFlags(this.artifact.flags);
     const result = await OclifUtils.execCoreCommand(projectDeployCmd.buildConfig());
     this.internalState.status = result.status === 0 ? DeployStatus.Enum.Success : DeployStatus.Enum.Failed;
     if (result.status !== 0) {

--- a/src/release-manifest/artifactDeploySfCommand.ts
+++ b/src/release-manifest/artifactDeploySfCommand.ts
@@ -1,0 +1,78 @@
+import { SfCommandConfig } from '../common/utils/sfCommandConfig.js';
+
+export default class ArtifactDeploySfCommand {
+  /**
+   * Colon-separated oclif identifier, e.g. project:deploy:start or package:install
+   */
+  public oclifIdentifier: string;
+
+  /**
+   * All parsed flags that will be applied when config is build. Flags are
+   * unique by their identifier.
+   */
+  public commandFlags: Map<string, string | undefined>;
+
+  public constructor(oclifIdentifier: string, flags?: SfCommandFlag[]) {
+    this.oclifIdentifier = oclifIdentifier;
+    this.commandFlags = new Map();
+    if (flags) {
+      flags.forEach((conf) => {
+        this.commandFlags.set(conf.name, conf.value);
+      });
+    }
+  }
+
+  /**
+   * Parses unstructured string input to internal flags dictionary. All
+   * values are written into the internal state.
+   *
+   * @param flagsInput
+   */
+  public parseFlags(flagsInput?: string): void {
+    if (!flagsInput || flagsInput.length === 0) {
+      return;
+    }
+    flagsInput
+      .trim()
+      .split(/\s+/)
+      .forEach((flagIdentifier) => {
+        const flagKeyValue = flagIdentifier.replace(/^-+/, '').split('=');
+        this.commandFlags.set(flagKeyValue[0], flagKeyValue[1]);
+      });
+  }
+
+  /**
+   * Adds a flag config to the internal flags dictionary.
+   *
+   * @param identifier
+   * @param value
+   */
+  public addFlag(identifier: string, value?: string): void {
+    if (identifier.length === 0) {
+      throw Error('Flag identifier cannot be empty');
+    }
+    this.commandFlags.set(identifier, value);
+  }
+
+  /**
+   * Builds the command arguments that can be used to execute
+   */
+  public buildConfig(): SfCommandConfig {
+    const args = [];
+    for (const [key, value] of this.commandFlags.entries()) {
+      args.push(`--${key}`);
+      if (value) {
+        args.push(`${value}`);
+      }
+    }
+    return {
+      name: this.oclifIdentifier,
+      args,
+    };
+  }
+}
+
+export type SfCommandFlag = {
+  name: string;
+  value?: string;
+};

--- a/src/release-manifest/artifactDeploySfCommand.ts
+++ b/src/release-manifest/artifactDeploySfCommand.ts
@@ -37,7 +37,9 @@ export default class ArtifactDeploySfCommand {
       .split(/\s+/)
       .forEach((flagIdentifier) => {
         const flagKeyValue = flagIdentifier.replace(/^-+/, '').split('=');
-        this.commandFlags.set(flagKeyValue[0], flagKeyValue[1]);
+        if (flagKeyValue[0].length > 1) {
+          this.commandFlags.set(flagKeyValue[0], flagKeyValue[1]);
+        }
       });
   }
 

--- a/src/types/orgManifestInputSchema.ts
+++ b/src/types/orgManifestInputSchema.ts
@@ -8,7 +8,11 @@ import { ScheduledJobConfig } from './scheduledApexTypes.js';
 
 const ZEnvironments = z.record(z.string());
 
-const ZUnlockedPackage = z.object({
+const ZArtifactBase = z.object({
+  flags: z.string().optional(),
+});
+
+const ZUnlockedPackage = ZArtifactBase.extend({
   type: z.literal(ArtifactTypes.Enum.UnlockedPackage),
   package_id: z.string(),
   installation_key: z.string().optional(),
@@ -16,12 +20,13 @@ const ZUnlockedPackage = z.object({
   version: z.string().regex(/^(\d+\.\d+\.\d+)$/, { message: 'Set version as MAJOR.MINOR.PATH (e.g. 1.4.0)' }),
 });
 
-const ZUnpackagedSource = z.object({
+const ZUnpackagedSource = ZArtifactBase.extend({
   type: z.literal(ArtifactTypes.Enum.Unpackaged),
   path: z.string().or(z.record(z.string())),
 });
 
-const ZCronJob = ScheduledJobConfig.extend({
+const ZCronJob = ZArtifactBase.extend({
+  ...ScheduledJobConfig.shape,
   type: z.literal(ArtifactTypes.Enum.CronJob),
 });
 

--- a/test/commands/jsc/manifest/validate.test.ts
+++ b/test/commands/jsc/manifest/validate.test.ts
@@ -73,4 +73,20 @@ describe('jsc manifest validate', () => {
       'args for spinner.stop() calls'
     );
   });
+
+  it('validates yaml with syntactically correct flags', async () => {
+    // Act
+    const result = await JscManifestValidate.run([
+      '--devhub-org',
+      $$.testDevHub.username,
+      '--target-org',
+      $$.testTargetOrg.username,
+      '--manifest',
+      'test/data/manifests/with-flags.yaml',
+    ]);
+
+    // Assert
+    expect(result.deployedArtifacts['org_shape_settings'][0].status).to.equal(DeployStatus.Enum.Resolved);
+    expect(result.deployedArtifacts['apex_utils'][0].status).to.equal(DeployStatus.Enum.Resolved);
+  });
 });

--- a/test/common/artifactDeploySfCommand.test.ts
+++ b/test/common/artifactDeploySfCommand.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import ArtifactDeploySfCommand from '../../src/release-manifest/artifactDeploySfCommand.js';
+
+describe('artifact deploy command builder', () => {
+  describe('initialisation', () => {
+    it('prepares command from constructor input', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install', [
+        { name: 'wait', value: '10' },
+        { name: 'upgrade-type', value: 'Mixed' },
+        { name: 'json' },
+      ]);
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal(['wait', 'upgrade-type', 'json']);
+      expect(sfCmd.commandFlags.get('upgrade-type')).to.equal('Mixed');
+      expect(sfCmd.commandFlags.get('wait')).to.equal('10');
+      expect(sfCmd.commandFlags.get('json')).to.be.undefined;
+      expect(sfCmd.buildConfig()).to.deep.equal({
+        name: 'package:install',
+        args: ['--wait', '10', '--upgrade-type', 'Mixed', '--json'],
+      });
+    });
+  });
+
+  describe('flag parsing', () => {
+    it('parses syntactically correct key-value flags successfully', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install');
+      sfCmd.parseFlags('upgrade-type=DeprecateOnly wait=20 apex-compile=package');
+
+      // Assert
+      const expectedKeys = ['upgrade-type', 'wait', 'apex-compile'];
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal(expectedKeys);
+      expect(sfCmd.commandFlags.get('upgrade-type')).to.equal('DeprecateOnly');
+      expect(sfCmd.commandFlags.get('wait')).to.equal('20');
+      expect(sfCmd.commandFlags.get('apex-compile')).to.equal('package');
+    });
+
+    it('parses syntactically correct key-value flags with many spaces successfully', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install');
+      sfCmd.parseFlags('   upgrade-type=DeprecateOnly      wait=20  ');
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal(['upgrade-type', 'wait']);
+      expect(sfCmd.commandFlags.get('upgrade-type')).to.equal('DeprecateOnly');
+      expect(sfCmd.commandFlags.get('wait')).to.equal('20');
+    });
+
+    it('parses syntactically correct key flags successfully', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('project:deploy:start');
+      sfCmd.parseFlags('ignore-conflicts verbose');
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal(['ignore-conflicts', 'verbose']);
+      expect(sfCmd.commandFlags.get('ignore-conflicts')).to.be.undefined;
+      expect(sfCmd.commandFlags.get('verbose')).to.be.undefined;
+    });
+
+    it('overrides flags from initialisation with parsed flags', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('project:deploy:start', [{ name: 'wait', value: '10' }]);
+      sfCmd.parseFlags('ignore-conflicts wait=20');
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal(['wait', 'ignore-conflicts']);
+      expect(sfCmd.commandFlags.get('ignore-conflicts')).to.be.undefined;
+      expect(sfCmd.commandFlags.get('wait')).to.equal('20');
+    });
+
+    it('ignores trailing dashes (-- and -)', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install');
+      sfCmd.parseFlags('--ignore-conflicts');
+      sfCmd.parseFlags('-other-flag');
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal(['ignore-conflicts', 'other-flag']);
+    });
+
+    it('ignores empty flags string', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install');
+      sfCmd.parseFlags('');
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal([]);
+    });
+
+    it('ignores undefined flags string', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install');
+      sfCmd.parseFlags(undefined);
+
+      // Assert
+      expect(Array.from(sfCmd.commandFlags.keys())).to.deep.equal([]);
+    });
+
+    it('overrides initialised flag with manual flag', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install', [{ name: 'installation-key', value: 'abc' }]);
+      sfCmd.addFlag('installation-key', 'def');
+
+      // Assert
+      expect(sfCmd.commandFlags.get('installation-key')).to.equal('def');
+    });
+
+    it('overrides initialised flag with empty flag', () => {
+      // Act
+      const sfCmd = new ArtifactDeploySfCommand('package:install', [{ name: 'installation-key', value: 'abc' }]);
+      sfCmd.addFlag('installation-key', undefined);
+
+      // Assert
+      expect(sfCmd.commandFlags.get('installation-key')).to.equal(undefined);
+      expect(sfCmd.buildConfig()).to.deep.equal({
+        name: 'package:install',
+        args: ['--installation-key'],
+      });
+    });
+  });
+});

--- a/test/data/manifests/with-flags.yaml
+++ b/test/data/manifests/with-flags.yaml
@@ -1,0 +1,16 @@
+environments:
+  dev: admin-salesforce@mobilityhouse.com.dev
+  qa: admin@example.com.qa
+  prod: admin@example.com
+artifacts:
+  org_shape_settings:
+    type: Unpackaged
+    path: test/data/mock-src/unpackaged/org-shape
+    flags: ignore-conflicts concise
+  apex_utils:
+    type: UnlockedPackage
+    package_id: 0Ho690000000000AAA
+    installation_key: APEX_UTILS_INSTALLATION_KEY
+    version: 1.28.0
+    skip_if_installed: false
+    flags: upgrade-type=DeprecateOnly wait=20 apex-compile=package


### PR DESCRIPTION
- optional `flags` parameter for each artifact type
- allows to customize (and hack) the underlying commands